### PR TITLE
exfat: support to build some exfat tools on Android.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,200 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+LOCAL_PATH:= $(call my-dir)
+
+exfat_common_cflags := -DHAVE_CONFIG_H -std=gnu99
+
+########################################
+# static library: libexfat.a
+
+libexfat_src_files := \
+    libexfat/cluster.c \
+    libexfat/io.c \
+    libexfat/log.c \
+    libexfat/lookup.c \
+    libexfat/mount.c \
+    libexfat/node.c \
+    libexfat/time.c \
+    libexfat/utf.c \
+    libexfat/utils.c
+
+libexfat_headers := \
+    $(LOCAL_PATH)/android \
+    $(LOCAL_PATH)/libexfat
+
+## TARGET ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libexfat
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(libexfat_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(libexfat_headers)
+
+include $(BUILD_STATIC_LIBRARY)
+
+## HOST ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libexfat
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(libexfat_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(libexfat_headers)
+
+include $(BUILD_HOST_STATIC_LIBRARY)
+
+
+########################################
+# executable: mkexfatfs
+
+mkexfatfs_src_files := \
+    mkfs/cbm.c \
+    mkfs/fat.c \
+    mkfs/main.c \
+    mkfs/mkexfat.c \
+    mkfs/rootdir.c \
+    mkfs/uct.c \
+    mkfs/uctc.c \
+    mkfs/vbr.c
+
+mkexfatfs_headers := \
+    $(libexfat_headers) \
+    $(LOCAL_PATH)/mkfs
+
+## TARGET ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := mkexfatfs
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(mkexfatfs_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(mkexfatfs_headers)
+LOCAL_STATIC_LIBRARIES := libexfat
+
+include $(BUILD_EXECUTABLE)
+
+## HOST ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := mkexfatfs
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(mkexfatfs_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(mkexfatfs_headers)
+LOCAL_STATIC_LIBRARIES := libexfat
+
+include $(BUILD_HOST_EXECUTABLE)
+
+########################################
+# executable: exfatfsck
+
+exfatfsck_src_files := fsck/main.c
+
+exfatfsck_headers := \
+    $(libexfat_headers) \
+    $(LOCAL_PATH)/fsck
+
+## TARGET ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := exfatfsck
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(exfatfsck_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(exfatfsck_headers)
+LOCAL_STATIC_LIBRARIES := libexfat
+
+include $(BUILD_EXECUTABLE)
+
+## HOST ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := exfatfsck
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(exfatfsck_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(exfatfsck_headers)
+LOCAL_STATIC_LIBRARIES := libexfat
+
+include $(BUILD_HOST_EXECUTABLE)
+
+########################################
+# executable: dumpexfat
+
+dumpexfat_src_files := dump/main.c
+
+dumpexfat_headers := \
+    $(libexfat_headers) \
+    $(LOCAL_PATH)/dump
+
+## TARGET ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := dumpexfat
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(dumpexfat_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(dumpexfat_headers)
+LOCAL_STATIC_LIBRARIES := libexfat
+
+include $(BUILD_EXECUTABLE)
+
+## HOST ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := dumpexfat
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(dumpexfat_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(dumpexfat_headers)
+LOCAL_STATIC_LIBRARIES := libexfat
+
+include $(BUILD_HOST_EXECUTABLE)
+
+########################################
+# executable: exfatlabel
+
+exfatlabel_src_files := label/main.c
+
+exfatlabel_headers := \
+    $(libexfat_headers) \
+    $(LOCAL_PATH)/label
+
+## TARGET ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := exfatlabel
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(exfatlabel_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(exfatlabel_headers)
+LOCAL_STATIC_LIBRARIES := libexfat
+
+include $(BUILD_EXECUTABLE)
+
+## HOST ##
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := exfatlabel
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(exfatlabel_src_files)
+LOCAL_CFLAGS := $(exfat_common_cflags)
+LOCAL_C_INCLUDES := $(exfatlabel_headers)
+LOCAL_STATIC_LIBRARIES := libexfat
+
+include $(BUILD_HOST_EXECUTABLE)

--- a/android/config.h
+++ b/android/config.h
@@ -1,0 +1,37 @@
+/* libexfat/config.h.  Generated from config.h.in by configure.  */
+/* libexfat/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Name of package */
+#define PACKAGE "exfat"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "relan@users.noreply.github.com"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "Free exFAT implementation"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "Free exFAT implementation 1.2.6"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "exfat"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "https://github.com/relan/exfat"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.2.6"
+
+/* Version number of package */
+#define VERSION "1.2.6"
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#define _FILE_OFFSET_BITS 64
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */


### PR DESCRIPTION
Now, add support to build mkexfatfs, exfatfsck, dumpexfat and exfatlabel

Change-Id: I9856f087157fde528e999dab316ede1662ba5b67
Signed-off-by: liminghao <liminghao@xiaomi.com>