### PR TITLE
Android: fix logcat support building in AOSP

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -39,6 +39,9 @@ libexfat_headers := \
     $(LOCAL_PATH)/android \
     $(LOCAL_PATH)/libexfat
 
+libexfat_shared_libraries := \
+    liblog
+
 ## TARGET ##
 include $(CLEAR_VARS)
 
@@ -47,6 +50,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES := $(libexfat_src_files)
 LOCAL_CFLAGS := $(exfat_common_cflags)
 LOCAL_C_INCLUDES := $(libexfat_headers)
+LOCAL_SHARED_LIBRARIES := $(libexfat_shared_libraries)
 
 include $(BUILD_STATIC_LIBRARY)
 

--- a/libexfat/log.c
+++ b/libexfat/log.c
@@ -48,7 +48,7 @@ void exfat_bug(const char* format, ...)
 	fputs(".\n", stderr);
 
 #ifdef __ANDROID__
-	__android_log_vprint(ANDROID_LOG_FATAL, PACKAGE, fmt, aq);
+	__android_log_vprint(ANDROID_LOG_FATAL, PACKAGE, format, aq);
 #else
 	if (!isatty(STDERR_FILENO))
 		vsyslog(LOG_CRIT, format, aq);
@@ -76,7 +76,7 @@ void exfat_error(const char* format, ...)
 	fputs(".\n", stderr);
 
 #ifdef __ANDROID__
-	__android_log_vprint(ANDROID_LOG_ERROR, PACKAGE, fmt, aq);
+	__android_log_vprint(ANDROID_LOG_ERROR, PACKAGE, format, aq);
 #else
 	if (!isatty(STDERR_FILENO))
 		vsyslog(LOG_ERR, format, aq);
@@ -102,7 +102,7 @@ void exfat_warn(const char* format, ...)
 	fputs(".\n", stderr);
 
 #ifdef __ANDROID__
-	__android_log_vprint(ANDROID_LOG_WARN, PACKAGE, fmt, aq);
+	__android_log_vprint(ANDROID_LOG_WARN, PACKAGE, format, aq);
 #else
 	if (!isatty(STDERR_FILENO))
 		vsyslog(LOG_WARNING, format, aq);


### PR DESCRIPTION
Building failed this way:

log.c:51:51: error: use of undeclared identifier fmt
        __android_log_vprint(ANDROID_LOG_FATAL, PACKAGE, fmt, aq);
                                                         ^
log.c:79:51: error: use of undeclared identifier fmt
        __android_log_vprint(ANDROID_LOG_ERROR, PACKAGE, fmt, aq);
                                                         ^
log.c:105:50: error: use of undeclared identifier fmt
        __android_log_vprint(ANDROID_LOG_WARN, PACKAGE, fmt, aq);
                                                        ^