### PR TITLE
Initial CMake build system support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,61 @@
+#
+# CMakeLists.txt (29.12.17)
+# CMake build system
+#
+# Free exFAT implementation.
+# Copyright (C) 2010-2017  Andrew Nayenko
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+cmake_minimum_required(VERSION 3.1)
+project(exfat
+  VERSION 1.2.7
+  DESCRIPTION "Free exFAT implementation"
+  LANGUAGES C
+)
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the build type" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "None" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+set(CMAKE_C_STANDARD 99)
+add_compile_options(-Wall -Werror)
+
+find_package(FUSE REQUIRED)
+
+# FUSE requires 64-bit off_t and FUSE2 unconditionally expects this macro.
+set(_FILE_OFFSET_BITS 64)
+
+configure_file(libexfat/cmakeconfig.h.in libexfat/config.h)
+
+include(GNUInstallDirs)
+function(install_symlink target link_name)
+  get_filename_component(_dir "${link_name}" DIRECTORY)
+  get_filename_component(_name "${link_name}" NAME)
+  set(temp_link "${CMAKE_CURRENT_BINARY_DIR}/${_name}")
+  execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink "${target}" "${temp_link}")
+  install(FILES "${temp_link}" DESTINATION "${_dir}" RENAME "${_name}")
+endfunction()
+
+add_subdirectory(libexfat)
+add_subdirectory(dump)
+add_subdirectory(fsck)
+add_subdirectory(fuse)
+add_subdirectory(label)
+add_subdirectory(mkfs)

--- a/cmake/modules/FindFUSE.cmake
+++ b/cmake/modules/FindFUSE.cmake
@@ -1,0 +1,38 @@
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_FUSE QUIET fuse)
+
+find_path(FUSE_INCLUDE_DIR
+  NAMES fuse.h
+  HINTS ${PC_FUSE_INCLUDE_DIRS}
+)
+find_library(FUSE_LIBRARY
+  NAMES fuse
+  HINTS ${PC_FUSE_LIBRARY_DIRS}
+)
+
+if(PC_FUSE_FOUND)
+  set(FUSE_VERSION "${PC_FUSE_VERSION}")
+elseif(FUSE_INCLUDE_DIR AND EXISTS "${FUSE_INCLUDE_DIR}/fuse_common.h")
+  set(_major_version_regex "#define[ \t]+FUSE_MAJOR_VERSION[ \t]+([0-9]+).*")
+  set(_minor_version_regex "#define[ \t]+FUSE_MINOR_VERSION[ \t]+([0-9]+).*")
+  file(STRINGS "${FUSE_INCLUDE_DIR}/fuse_common.h"
+    _fuse_version REGEX "^(${_major_version_regex}|${_minor_version_regex})")
+  string(REGEX REPLACE ".*${_major_version_regex}" "\\1"
+    _fuse_major_version "${_fuse_version}")
+  string(REGEX REPLACE ".*${_minor_version_regex}" "\\1"
+    _fuse_minor_version "${_fuse_version}")
+  set(FUSE_VERSION "${_fuse_major_version}.${_fuse_minor_version}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set FUSE_FOUND to TRUE
+# if all listed variables are TRUE and the requested version matches.
+find_package_handle_standard_args(FUSE REQUIRED_VARS
+                                  FUSE_LIBRARY FUSE_INCLUDE_DIR
+                                  VERSION_VAR FUSE_VERSION)
+
+if(FUSE_FOUND)
+  set(FUSE_LIBRARIES     ${FUSE_LIBRARY})
+  set(FUSE_INCLUDE_DIRS  ${FUSE_INCLUDE_DIR})
+endif()
+mark_as_advanced(FUSE_INCLUDE_DIR FUSE_LIBRARY)

--- a/dump/CMakeLists.txt
+++ b/dump/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# CMakeLists.txt (29.12.17)
+# CMake build system
+#
+# Free exFAT implementation.
+# Copyright (C) 2011-2017  Andrew Nayenko
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+add_executable(dumpexfat main.c)
+target_link_libraries(dumpexfat libexfat)
+
+install(TARGETS dumpexfat DESTINATION ${CMAKE_INSTALL_SBINDIR})
+install(FILES dumpexfat.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)

--- a/fsck/CMakeLists.txt
+++ b/fsck/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# CMakeLists.txt (29.12.17)
+# CMake build system
+#
+# Free exFAT implementation.
+# Copyright (C) 2011-2017  Andrew Nayenko
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+add_executable(exfatfsck main.c)
+target_link_libraries(exfatfsck libexfat)
+
+install(TARGETS exfatfsck DESTINATION ${CMAKE_INSTALL_SBINDIR})
+install(FILES exfatfsck.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
+install_symlink(exfatfsck ${CMAKE_INSTALL_SBINDIR}/fsck.exfat)

--- a/fuse/CMakeLists.txt
+++ b/fuse/CMakeLists.txt
@@ -1,0 +1,34 @@
+#
+# CMakeLists.txt (29.12.17)
+# CMake build system
+#
+# Free exFAT implementation.
+# Copyright (C) 2010-2017  Andrew Nayenko
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+add_executable(mount.exfat-fuse main.c)
+target_include_directories(mount.exfat-fuse PRIVATE
+  ${FUSE_INCLUDE_DIRS}
+)
+target_link_libraries(mount.exfat-fuse
+  libexfat
+  ${FUSE_LIBRARIES}
+)
+
+install(TARGETS mount.exfat-fuse DESTINATION ${CMAKE_INSTALL_SBINDIR})
+install(FILES mount.exfat-fuse.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
+install_symlink(mount.exfat-fuse ${CMAKE_INSTALL_SBINDIR}/mount.exfat)

--- a/label/CMakeLists.txt
+++ b/label/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# CMakeLists.txt (29.12.17)
+# CMake build system
+#
+# Free exFAT implementation.
+# Copyright (C) 2011-2017  Andrew Nayenko
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+add_executable(exfatlabel main.c)
+target_link_libraries(exfatlabel libexfat)
+
+install(TARGETS exfatlabel DESTINATION ${CMAKE_INSTALL_SBINDIR})
+install(FILES exfatlabel.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)

--- a/libexfat/CMakeLists.txt
+++ b/libexfat/CMakeLists.txt
@@ -1,0 +1,39 @@
+#
+# CMakeLists.txt (29.12.17)
+# CMake build system
+#
+# Free exFAT implementation.
+# Copyright (C) 2010-2017  Andrew Nayenko
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+add_library(libexfat STATIC
+  cluster.c
+  io.c
+  log.c
+  lookup.c
+  mount.c
+  node.c
+  time.c
+  utf.c
+  utils.c
+)
+
+# Allow dependencies to find our headers and config.h
+target_include_directories(libexfat PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/libexfat/cmakeconfig.h.in
+++ b/libexfat/cmakeconfig.h.in
@@ -1,0 +1,7 @@
+/* cmakeconfig.h.in */
+
+/* Version number of package */
+#define VERSION "@PROJECT_VERSION@"
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#cmakedefine _FILE_OFFSET_BITS @_FILE_OFFSET_BITS@

--- a/mkfs/CMakeLists.txt
+++ b/mkfs/CMakeLists.txt
@@ -1,0 +1,37 @@
+#
+# CMakeLists.txt (29.12.17)
+# CMake build system
+#
+# Free exFAT implementation.
+# Copyright (C) 2011-2017  Andrew Nayenko
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+add_executable(mkexfatfs
+  cbm.c
+  fat.c
+  main.c
+  mkexfat.c
+  rootdir.c
+  uct.c
+  uctc.c
+  vbr.c
+)
+target_link_libraries(mkexfatfs libexfat)
+
+install(TARGETS mkexfatfs DESTINATION ${CMAKE_INSTALL_SBINDIR})
+install(FILES mkexfatfs.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
+install_symlink(mkexfatfs ${CMAKE_INSTALL_SBINDIR}/mkfs.exfat)


### PR DESCRIPTION
Supports out-of-tree builds without cluttering the source tree (as is
the case with autotools) and enable faster builds with Ninja.

The only missing "feature" from autotools is an uninstall target. To
mimic this after the install target: `xargs rm < install_manifest.txt`

Note that header files are not listed in the sources list, CMake
automatically discovers what headers are needed.
___
Main advantage is support for out-of-source-tree builds **without cluttering the source tree**. Nice side-effect is that a fresh build is 7x faster than autotools. The dependencies autoconf + automake + pkg-config + make can be replaced by cmake + ninja (optional, but recommended).

Build time (n=10, tmpfs):

autotools

| command | time | remark
| --- | --- | ---
| `autoreconf -i` | 2.55s
| `mkdir build && cd build && ../configure` | 1.52s
| `make` | 1.70s | `make -j10` time: 0.84s
| `DESTDIR=$PWD/fs make install` | 0.20s | `make -j10 install` time: 0.15s
| total | **5.97s** | with parallel make: 5.06
| `make` | 0.075s | incremental build with no changes; `make -j10` time: 0.065s

cmake + Ninja

| command | time | remark
| --- | --- | ---
| `mkdir build && cd build && cmake -GNinja ..` | 0.366s | no need for autoreconf, corresponds to configure
| `ninja` | 0.468s
| `DESTDIR=$PWD/fs ninja install` | 0.012s
| total | **0.846s**
| `ninja` | 0.003s | incremental build with no changes