### PR TITLE
Fix predefined macro for DragonFlyBSD

### DIFF
--- a/libexfat/platform.h
+++ b/libexfat/platform.h
@@ -46,7 +46,7 @@
 #define EXFAT_LITTLE_ENDIAN LITTLE_ENDIAN
 #define EXFAT_BIG_ENDIAN BIG_ENDIAN
 
-#elif defined(__FreeBSD__) || defined(__DragonFlyBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
 
 #include <sys/endian.h>
 #define exfat_bswap16(x) bswap16(x)


### PR DESCRIPTION
\_\_DragonFlyBSD\_\_ is not defined in DragonFlyBSD.
It's \_\_DragonFly\_\_ without "BSD".