### PR TITLE
Remove tags config in Android.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -27,7 +27,6 @@ cc_defaults {
         "-DPACKAGE=\"exfat\"",
         "-DVERSION=\"1.3.0\"",
     ],
-    tags: ["optional"],
     shared_libs: ["liblog"],
 }
 


### PR DESCRIPTION
Android's build system don't support "tags" now, we need to remove this config to fix the compile error.