### PR TITLE
Add support for timezone offsets

### DIFF
--- a/libexfat/exfat.h
+++ b/libexfat/exfat.h
@@ -228,9 +228,10 @@ int exfat_set_label(struct exfat* ef, const char* label);
 int exfat_mount(struct exfat* ef, const char* spec, const char* options);
 void exfat_unmount(struct exfat* ef);
 
-time_t exfat_exfat2unix(le16_t date, le16_t time, uint8_t centisec);
+time_t exfat_exfat2unix(le16_t date, le16_t time, uint8_t centisec,
+		uint8_t tzoffset);
 void exfat_unix2exfat(time_t unix_time, le16_t* date, le16_t* time,
-		uint8_t* centisec);
+		uint8_t* centisec, uint8_t* tzoffset);
 void exfat_tzset(void);
 
 bool exfat_ask_to_fix(const struct exfat* ef);

--- a/libexfat/exfatfs.h
+++ b/libexfat/exfatfs.h
@@ -144,7 +144,8 @@ struct exfat_entry_meta1			/* file or directory info (part 1) */
 	le16_t atime, adate;			/* latest access date and time */
 	uint8_t crtime_cs;				/* creation time in cs (centiseconds) */
 	uint8_t mtime_cs;				/* latest modification time in cs */
-	uint8_t __unknown2[10];
+	uint8_t crtime_tzo, mtime_tzo, atime_tzo;	/* timezone offset encoded */
+	uint8_t __unknown2[7];
 }
 PACKED;
 STATIC_ASSERT(sizeof(struct exfat_entry_meta1) == 32);

--- a/libexfat/time.c
+++ b/libexfat/time.c
@@ -53,7 +53,8 @@ static const time_t days_in_year[] =
 	0,   0,  31,  59,  90, 120, 151, 181, 212, 243, 273, 304, 334
 };
 
-time_t exfat_exfat2unix(le16_t date, le16_t time, uint8_t centisec)
+time_t exfat_exfat2unix(le16_t date, le16_t time, uint8_t centisec,
+		uint8_t tzoffset)
 {
 	time_t unix_time = EPOCH_DIFF_SEC;
 	uint16_t ndate = le16_to_cpu(date);
@@ -100,13 +101,18 @@ time_t exfat_exfat2unix(le16_t date, le16_t time, uint8_t centisec)
 	unix_time += centisec / 100;
 
 	/* exFAT stores timestamps in local time, so we correct it to UTC */
-	unix_time += exfat_timezone;
+	if(tzoffset & 0x80)
+		/* lower 7 bits are signed timezone offset in 15 minute increments */
+		unix_time -= (int8_t)(tzoffset << 1) * 15 * 60 / 2;
+	else
+		/* timezone offset not present, assume our local timezone */
+		unix_time += exfat_timezone;
 
 	return unix_time;
 }
 
 void exfat_unix2exfat(time_t unix_time, le16_t* date, le16_t* time,
-		uint8_t* centisec)
+		uint8_t* centisec, uint8_t* tzoffset)
 {
 	time_t shift = EPOCH_DIFF_SEC + exfat_timezone;
 	uint16_t day, month, year;
@@ -146,6 +152,9 @@ void exfat_unix2exfat(time_t unix_time, le16_t* date, le16_t* time,
 	*time = cpu_to_le16(twosec | (min << 5) | (hour << 11));
 	if (centisec)
 		*centisec = (unix_time % 2) * 100;
+
+	/* record our local timezone offset in exFAT (15 minute increment) format */
+	*tzoffset = (uint8_t)(-exfat_timezone / 60 / 15) | 0x80;
 }
 
 void exfat_tzset(void)


### PR DESCRIPTION
Fixes #70.  The timezone offset field is used, if present, to convert the stored local timestamp to the current timezone on read.  The current timezone is set into the offset field when updating a timestamp.

To validate this change, I created files in many different timezones on an exFAT image.  I was sure to include TZs that fall on 15 minute offsets.  I also accounted for the necessary unmount/mount when changing timezones with fuse-exfat.  The systems used to create the files were:
* Windows 7
* OS X 10.12.6
* fuse-exfat-1.3.0 on Mint 18 amd64
* fuse-exfat-1.3.0 + this patch

I then generated a dir listing of the exFAT image as read by all 4 systems.  In summary:
* Windows, OS X, and patched 1.3.0 list all files identically.  (Ignoring the mtime cs on the files OS X wrote, which are also not displayed by the unpatched 1.3.0 either.)
* Patched 1.3.0 lists files written by unpatched 1.3.0 identically.
* Unpatched 1.3.0 incorrectly lists files written by Windows and OS X.  This patch fixes that.
* Unpatched 1.3.0 incorrectly lists files written by patched 1.3.0 in the same way it incorrectly lists files written by Windows and OS X.

I feel that the last point is acceptable.  The point of using exFAT is for OS interoperability, and this patch improves upon that.  Additionally, any user with both unpatched and patched systems will see no difference as long as both systems are in the same timezone.

Full listing results:
[fuse-exfat-1.3.0-patched-read.txt](https://github.com/relan/exfat/files/3096854/fuse-exfat-1.3.0-patched-read.txt)
[fuse-exfat-1.3.0-read.txt](https://github.com/relan/exfat/files/3096855/fuse-exfat-1.3.0-read.txt)
[osx-read.txt](https://github.com/relan/exfat/files/3096856/osx-read.txt)
[windows-read.txt](https://github.com/relan/exfat/files/3096857/windows-read.txt)

Additionally, I performed a check of all 3 timestamps (mtime, atime, and crtime) to validate that they are all updated correctly.  This was done by creating, editing, and accessing files under different timezones.