### PR TITLE
mkfs : Fix cluster_count

### DIFF
--- a/libexfat/mount.c
+++ b/libexfat/mount.c
@@ -293,12 +293,15 @@ int exfat_mount(struct exfat* ef, const char* spec, const char* options)
 				exfat_get_size(ef->dev));
 	}
 	if ((off_t) le32_to_cpu(ef->sb->cluster_count) * CLUSTER_SIZE(*ef->sb) >
-			exfat_get_size(ef->dev))
+			(le64_to_cpu(ef->sb->sector_count) - le32_to_cpu(ef->sb->cluster_sector_start))
+			* SECTOR_SIZE(*ef->sb))
 	{
-		exfat_error("file system in clusters is larger than device: "
-				"%u * %d > %"PRIu64,
+		exfat_error("file system in clusters is larger than file system in sectors: "
+				"%u * %d > (%"PRIu64" - %d) * %d",
 				le32_to_cpu(ef->sb->cluster_count), CLUSTER_SIZE(*ef->sb),
-				exfat_get_size(ef->dev));
+				le64_to_cpu(ef->sb->sector_count),
+				le32_to_cpu(ef->sb->cluster_sector_start),
+				SECTOR_SIZE(*ef->sb));
 		exfat_free(ef);
 		return -EIO;
 	}

--- a/mkfs/vbr.c
+++ b/mkfs/vbr.c
@@ -62,8 +62,7 @@ static void init_sb(struct exfat_super_block* sb)
 	sb->cluster_sector_start = cpu_to_le32(
 			get_position(&cbm) / get_sector_size());
 	sb->cluster_count = cpu_to_le32(clusters_max -
-			((le32_to_cpu(sb->fat_sector_start) +
-			  le32_to_cpu(sb->fat_sector_count)) >> get_spc_bits()));
+			(le32_to_cpu(sb->cluster_sector_start) >> get_spc_bits()));
 	sb->rootdir_cluster = cpu_to_le32(
 			(get_position(&rootdir) - get_position(&cbm)) / get_cluster_size()
 			+ EXFAT_FIRST_DATA_CLUSTER);


### PR DESCRIPTION
Cluster count is the number of cluster after cluster_sector_start.
This will allow to set cluster_sector_start alignment.