### PR TITLE
Android.bp: add soong_namespace

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17,6 +17,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+soong_namespace {
+}
+
 cc_defaults {
     name: "exfat_defaults",
 


### PR DESCRIPTION
Make the blueprint namespace-aware so several exfat implementations
can coexist in a tree and chosen at build time.

Documentation on how to choose the namespace and use the feature
can be found here:

https://source.android.com/setup/build#namespace_modules


Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>