### PR TITLE
attrib: Add tool to set or modify file attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Makefile
 
 # make
 *.o
+/attrib/exfatattrib
 /dump/dumpexfat
 /fsck/exfatfsck
 /fuse/mount.exfat-fuse

--- a/attrib/Makefile.am
+++ b/attrib/Makefile.am
@@ -3,7 +3,7 @@
 #	Automake source.
 #
 #	Free exFAT implementation.
-#	Copyright (C) 2010-2018  Andrew Nayenko
+#	Copyright (C) 2020  Endless OS Foundation LLC
 #
 #	This program is free software; you can redistribute it and/or modify
 #	it under the terms of the GNU General Public License as published by
@@ -20,4 +20,8 @@
 #	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-SUBDIRS = libexfat attrib dump fsck fuse label mkfs
+sbin_PROGRAMS = exfatattrib
+dist_man8_MANS = exfatattrib.8
+exfatattrib_SOURCES = main.c
+exfatattrib_CPPFLAGS = -I$(top_srcdir)/libexfat
+exfatattrib_LDADD = ../libexfat/libexfat.a

--- a/attrib/exfatattrib.8
+++ b/attrib/exfatattrib.8
@@ -23,6 +23,7 @@
 |
 .B \-A
 ]
+.B \-d
 .I device
 .I file
 .SH DESCRIPTION
@@ -44,6 +45,10 @@ error to set and clear the same flag.
 .SH COMMAND LINE OPTIONS
 Command line options available:
 
+.TP
+.BI \-d " device"
+The path to an unmounted disk partition or disk image file containing an exFAT
+filesystem. This option is required.
 .TP
 .BI -r
 Set read\-only flag

--- a/attrib/exfatattrib.8
+++ b/attrib/exfatattrib.8
@@ -1,0 +1,85 @@
+.\" Copyright (C) 2020 Endless OS Foundation
+.\"
+.TH EXFATATTRIB 8 "November 2020"
+.SH NAME
+.B exfatattrib
+\- Set or display exFAT file attributes
+.SH SYNOPSIS
+.B exfatattrib
+[
+.B \-r
+|
+.B \-R
+|
+.B \-i
+|
+.B \-I
+|
+.B \-s
+|
+.B \-S
+|
+.B \-a
+|
+.B \-A
+]
+.I device
+.I file
+.SH DESCRIPTION
+.B exfatattrib
+sets or displays attributes of a file on an exFAT filesystem.
+
+.I device
+is the path to an unmounted disk partition or disk image file containing an
+exFAT filesystem.
+
+.I file
+is the path of a file within that filesystem.
+
+If run with no command line options, the current attributes of
+.I file
+are displayed; otherwise, the specified attributes are set or cleared. It is an
+error to set and clear the same flag.
+
+.SH COMMAND LINE OPTIONS
+Command line options available:
+
+.TP
+.BI -r
+Set read\-only flag
+.TP
+.BI \-R
+Clear read\-only flag
+.TP
+.BI \-i
+Set hidden flag (mnemonic: \fBi\fRnvisible)
+.TP
+.BI \-I
+Clear hidden flag
+.TP
+.BI \-s
+Set system flag
+.TP
+.BI \-S
+Clear system flag
+.TP
+.BI \-a
+Set archive flag
+.TP
+.BI \-A
+Clear archive flag
+.TP
+.BI \-h
+Display this help message
+.TP
+.BI \-V
+Print version and copyright.
+
+.SH EXIT CODES
+Zero is returned if errors were not found. Any other code means an error.
+
+.SH AUTHOR
+Will Thompson
+
+.SH SEE ALSO
+.BR chmod(1)

--- a/attrib/main.c
+++ b/attrib/main.c
@@ -1,0 +1,171 @@
+/*
+	main.c (20.01.11)
+	Prints or changes exFAT file attributes
+
+	Free exFAT implementation.
+	Copyright (C) 2020       Endless OS Foundation LLC
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License along
+	with this program; if not, write to the Free Software Foundation, Inc.,
+	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <exfat.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static void usage(const char* prog)
+{
+	fprintf(stderr,
+		"Display current attributes:\n"
+		"  %1$s <device> <file>\n"
+		"\n"
+		"Set attributes:\n"
+		"  %1$s [FLAGS] <device> <file>\n"
+		"\n"
+		"Flags:\n"
+		"  -r    Set read-only flag\n"
+		"  -R    Clear read-only flag\n"
+		"  -i    Set hidden flag\n"
+		"  -I    Clear hidden flag\n"
+		"  -s    Set system flag\n"
+		"  -S    Clear system flag\n"
+		"  -a    Set archive flag\n"
+		"  -A    Clear archive flag\n"
+		"\n"
+		"  -h    Display this help message\n"
+		"  -V    Display version information\n",
+		prog);
+	exit(1);
+}
+
+static void print_attribute(uint16_t attribs, uint16_t attrib, const char *label)
+{
+	printf("%9s: %s\n", label, (attribs & attrib) ? "yes" : "no");
+}
+
+int main(int argc, char* argv[])
+{
+	int opt;
+	int ret;
+	const char* spec = NULL;
+	const char* options = "";
+	const char* file_path = NULL;
+	struct exfat ef;
+	struct exfat_node* node;
+	uint16_t add_flags = 0;
+	uint16_t clear_flags = 0;
+
+	while ((opt = getopt(argc, argv, "rRiIsSaAhV")) != -1)
+	{
+		switch (opt)
+		{
+		case 'V':
+			printf("exfatattrib %s\n", VERSION);
+			puts("Copyright (C) 2011-2018  Andrew Nayenko");
+			puts("Copyright (C) 2020       Endless OS Foundation LLC");
+			return 0;
+		case 'r':
+			add_flags |= EXFAT_ATTRIB_RO;
+			break;
+		case 'R':
+			clear_flags |= EXFAT_ATTRIB_RO;
+			break;
+		/* "-h[elp]" is taken; i is the second letter of "hidden" and
+		 * its synonym "invisible"
+		 */
+		case 'i':
+			add_flags |= EXFAT_ATTRIB_HIDDEN;
+			break;
+		case 'I':
+			clear_flags |= EXFAT_ATTRIB_HIDDEN;
+			break;
+		case 's':
+			add_flags |= EXFAT_ATTRIB_SYSTEM;
+			break;
+		case 'S':
+			clear_flags |= EXFAT_ATTRIB_SYSTEM;
+			break;
+		case 'a':
+			add_flags |= EXFAT_ATTRIB_ARCH;
+			break;
+		case 'A':
+			clear_flags |= EXFAT_ATTRIB_ARCH;
+			break;
+		default:
+			usage(argv[0]);
+		}
+	}
+
+	if ((add_flags & clear_flags) != 0)
+	{
+		exfat_error("Can't set and clear the same flag");
+		exit(1);
+	}
+
+	if (argc - optind != 2)
+		usage(argv[0]);
+
+	spec = argv[optind];
+	file_path = argv[optind + 1];
+
+	if ((add_flags | clear_flags) == 0)
+		options = "ro";
+
+	if ((ret = exfat_mount(&ef, spec, options)) != 0)
+	{
+		exfat_error("Failed to mount %s: %s", spec, strerror(-ret));
+		return 1;
+	}
+
+	if ((ret = exfat_lookup(&ef, &node, file_path)) != 0)
+	{
+		exfat_error("Failed to look up %s: %s", file_path, strerror(-ret));
+		return 1;
+	}
+
+	if ((add_flags | clear_flags) != 0)
+	{
+		uint16_t attrib = node->attrib;
+
+		attrib |= add_flags;
+		attrib &= ~clear_flags;
+
+		if (node->attrib != attrib)
+		{
+			node->attrib = attrib;
+			node->is_dirty = true;
+
+			if ((ret = exfat_flush_node(&ef, node)) != 0)
+			{
+				exfat_error("Failed to flush changes to %s: %s", file_path, strerror(-ret));
+				return 1;
+			}
+		}
+	}
+	else
+	{
+		print_attribute(node->attrib, EXFAT_ATTRIB_RO, "Read-only");
+		print_attribute(node->attrib, EXFAT_ATTRIB_HIDDEN, "Hidden");
+		print_attribute(node->attrib, EXFAT_ATTRIB_SYSTEM, "System");
+		print_attribute(node->attrib, EXFAT_ATTRIB_ARCH, "Archive");
+		/* Read-only attributes */
+		print_attribute(node->attrib, EXFAT_ATTRIB_VOLUME, "Volume");
+		print_attribute(node->attrib, EXFAT_ATTRIB_DIR, "Directory");
+	}
+
+	exfat_put_node(&ef, node);
+	exfat_unmount(&ef);
+	return 0;
+}

--- a/attrib/main.c
+++ b/attrib/main.c
@@ -29,10 +29,10 @@ static void usage(const char* prog)
 {
 	fprintf(stderr,
 		"Display current attributes:\n"
-		"  %1$s <device> <file>\n"
+		"  %1$s -d <device> <file>\n"
 		"\n"
 		"Set attributes:\n"
-		"  %1$s [FLAGS] <device> <file>\n"
+		"  %1$s [FLAGS] -d <device> <file>\n"
 		"\n"
 		"Flags:\n"
 		"  -r    Set read-only flag\n"
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
 	uint16_t add_flags = 0;
 	uint16_t clear_flags = 0;
 
-	while ((opt = getopt(argc, argv, "rRiIsSaAhV")) != -1)
+	while ((opt = getopt(argc, argv, "d:rRiIsSaAhV")) != -1)
 	{
 		switch (opt)
 		{
@@ -76,6 +76,14 @@ int main(int argc, char* argv[])
 			puts("Copyright (C) 2011-2018  Andrew Nayenko");
 			puts("Copyright (C) 2020       Endless OS Foundation LLC");
 			return 0;
+		/* The path to the unmounted exFAT partition is a (mandatory) named
+		 * option rather than a positional parameter. If the FUSE filesystem
+		 * ever gains an ioctl to get and set attributes, this option could be
+		 * made optional, and this tool taught to use the ioctl.
+		 */
+		case 'd':
+			spec = optarg;
+			break;
 		case 'r':
 			add_flags |= EXFAT_ATTRIB_RO;
 			break;
@@ -114,11 +122,10 @@ int main(int argc, char* argv[])
 		exit(1);
 	}
 
-	if (argc - optind != 2)
+	if (spec == NULL || argc - optind != 1)
 		usage(argv[0]);
 
-	spec = argv[optind];
-	file_path = argv[optind + 1];
+	file_path = argv[optind];
 
 	if ((add_flags | clear_flags) == 0)
 		options = "ro";

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,7 @@ esac
 AC_CONFIG_HEADERS([libexfat/config.h])
 AC_CONFIG_FILES([
 	libexfat/Makefile
+	attrib/Makefile
 	dump/Makefile
 	fsck/Makefile
 	fuse/Makefile


### PR DESCRIPTION
exFAT files may be marked as hidden, read-only, or system. While these
flags may be ignored on Unix platforms, it may be useful to mark a file
as hidden when building a filesystem image destined for use on Windows.

This new tool allows these three flags to be set or cleared on a single
file on a filesystem. If run with no flags, it displays the file's
current attributes, including "dir" and "arch" (whatever that is).
