### PR TITLE
Improve concurrent sequential access speed by per-file file pointer.

### DIFF
--- a/libexfat/exfat.h
+++ b/libexfat/exfat.h
@@ -71,6 +71,13 @@
    be corrupted with 32-bit off_t. */
 STATIC_ASSERT(sizeof(off_t) == 8);
 
+struct exfat_fptr
+{
+	uint32_t index;
+	cluster_t cluster;
+	struct exfat_fptr* next;
+};
+
 struct exfat_node
 {
 	struct exfat_node* parent;
@@ -79,8 +86,7 @@ struct exfat_node
 	struct exfat_node* prev;
 
 	int references;
-	uint32_t fptr_index;
-	cluster_t fptr_cluster;
+	struct exfat_fptr fptr;
 	off_t entry_offset;
 	cluster_t start_cluster;
 	uint16_t attrib;
@@ -162,9 +168,9 @@ ssize_t exfat_pread(struct exfat_dev* dev, void* buffer, size_t size,
 ssize_t exfat_pwrite(struct exfat_dev* dev, const void* buffer, size_t size,
 		off_t offset);
 ssize_t exfat_generic_pread(const struct exfat* ef, struct exfat_node* node,
-		void* buffer, size_t size, off_t offset);
+		void* buffer, size_t size, off_t offset, struct exfat_fptr* fh);
 ssize_t exfat_generic_pwrite(struct exfat* ef, struct exfat_node* node,
-		const void* buffer, size_t size, off_t offset);
+		const void* buffer, size_t size, off_t offset, struct exfat_fptr* fh);
 
 int exfat_opendir(struct exfat* ef, struct exfat_node* dir,
 		struct exfat_iterator* it);
@@ -179,7 +185,7 @@ off_t exfat_c2o(const struct exfat* ef, cluster_t cluster);
 cluster_t exfat_next_cluster(const struct exfat* ef,
 		const struct exfat_node* node, cluster_t cluster);
 cluster_t exfat_advance_cluster(const struct exfat* ef,
-		struct exfat_node* node, uint32_t count);
+		struct exfat_node* node, uint32_t count, struct exfat_fptr* fptr);
 int exfat_flush_nodes(struct exfat* ef);
 int exfat_flush(struct exfat* ef);
 int exfat_truncate(struct exfat* ef, struct exfat_node* node, uint64_t size,

--- a/libexfat/io.c
+++ b/libexfat/io.c
@@ -388,7 +388,7 @@ ssize_t exfat_pwrite(struct exfat_dev* dev, const void* buffer, size_t size,
 }
 
 ssize_t exfat_generic_pread(const struct exfat* ef, struct exfat_node* node,
-		void* buffer, size_t size, off_t offset)
+		void* buffer, size_t size, off_t offset, struct exfat_fptr* fptr)
 {
 	uint64_t newsize = offset;
 	cluster_t cluster;
@@ -402,7 +402,7 @@ ssize_t exfat_generic_pread(const struct exfat* ef, struct exfat_node* node,
 	if (size == 0)
 		return 0;
 
-	cluster = exfat_advance_cluster(ef, node, newsize / CLUSTER_SIZE(*ef->sb));
+	cluster = exfat_advance_cluster(ef, node, newsize / CLUSTER_SIZE(*ef->sb), fptr);
 	if (CLUSTER_INVALID(*ef->sb, cluster))
 	{
 		exfat_error("invalid cluster 0x%x while reading", cluster);
@@ -436,7 +436,7 @@ ssize_t exfat_generic_pread(const struct exfat* ef, struct exfat_node* node,
 }
 
 ssize_t exfat_generic_pwrite(struct exfat* ef, struct exfat_node* node,
-		const void* buffer, size_t size, off_t offset)
+		const void* buffer, size_t size, off_t offset, struct exfat_fptr* fptr)
 {
 	uint64_t newsize = offset;
 	int rc;
@@ -461,7 +461,7 @@ ssize_t exfat_generic_pwrite(struct exfat* ef, struct exfat_node* node,
 	if (size == 0)
 		return 0;
 
-	cluster = exfat_advance_cluster(ef, node, newsize / CLUSTER_SIZE(*ef->sb));
+	cluster = exfat_advance_cluster(ef, node, newsize / CLUSTER_SIZE(*ef->sb), fptr);
 	if (CLUSTER_INVALID(*ef->sb, cluster))
 	{
 		exfat_error("invalid cluster 0x%x while writing", cluster);

--- a/libexfat/mount.c
+++ b/libexfat/mount.c
@@ -303,7 +303,7 @@ int exfat_mount(struct exfat* ef, const char* spec, const char* options)
 	memset(ef->root, 0, sizeof(struct exfat_node));
 	ef->root->attrib = EXFAT_ATTRIB_DIR;
 	ef->root->start_cluster = le32_to_cpu(ef->sb->rootdir_cluster);
-	ef->root->fptr_cluster = ef->root->start_cluster;
+	ef->root->fptr.cluster = ef->root->start_cluster;
 	ef->root->name[0] = cpu_to_le16('\0');
 	ef->root->size = rootdir_size(ef);
 	if (ef->root->size == 0)

--- a/libexfat/node.c
+++ b/libexfat/node.c
@@ -67,6 +67,9 @@ int exfat_cleanup_node(struct exfat* ef, struct exfat_node* node)
 		exfat_bug("unable to cleanup a node with %d references",
 				node->references);
 
+	if (node->fptr.next != NULL)
+		exfat_bug("unable to cleanup a node with an open file handle");
+
 	if (node->is_unlinked)
 	{
 		/* free all clusters and node structure itself */
@@ -86,7 +89,7 @@ static int read_entries(struct exfat* ef, struct exfat_node* dir,
 		exfat_bug("attempted to read entries from a file");
 
 	size = exfat_generic_pread(ef, dir, entries,
-			sizeof(struct exfat_entry[n]), offset);
+			sizeof(struct exfat_entry[n]), offset, NULL);
 	if (size == (ssize_t) sizeof(struct exfat_entry) * n)
 		return 0; /* success */
 	if (size == 0)
@@ -107,7 +110,7 @@ static int write_entries(struct exfat* ef, struct exfat_node* dir,
 		exfat_bug("attempted to write entries into a file");
 
 	size = exfat_generic_pwrite(ef, dir, entries,
-			sizeof(struct exfat_entry[n]), offset);
+			sizeof(struct exfat_entry[n]), offset, NULL);
 	if (size == (ssize_t) sizeof(struct exfat_entry) * n)
 		return 0; /* success */
 	if (size < 0)
@@ -146,7 +149,7 @@ static void init_node_meta2(struct exfat_node* node,
 {
 	node->size = le64_to_cpu(meta2->size);
 	node->start_cluster = le32_to_cpu(meta2->start_cluster);
-	node->fptr_cluster = node->start_cluster;
+	node->fptr.cluster = node->start_cluster;
 	node->is_contiguous = ((meta2->flags & EXFAT_FLAG_CONTIGUOUS) != 0);
 }
 

--- a/libexfat/repair.c
+++ b/libexfat/repair.c
@@ -94,7 +94,7 @@ bool exfat_fix_unknown_entry(struct exfat* ef, struct exfat_node* dir,
 
 	deleted.type &= ~EXFAT_ENTRY_VALID;
 	if (exfat_generic_pwrite(ef, dir, &deleted, sizeof(struct exfat_entry),
-			offset) != sizeof(struct exfat_entry))
+			offset, NULL) != sizeof(struct exfat_entry))
 		return false;
 
 	exfat_errors_fixed++;


### PR DESCRIPTION
This PR addresses #181 by adding a separate "fptr" for each open file handle, so that sequential reads never have to restart from the beginning of the file.

In light testing on an i7 CPU with an external SSD, the PR allows concurrent readers at different positions in a large file to achieve the same total read throughput and CPU usage as a single reader sequentially processing the whole file.

Any feedback would be gratefully received.