### PR TITLE
Add date and time repair for fsck

### DIFF
--- a/libexfat/exfat.h
+++ b/libexfat/exfat.h
@@ -240,5 +240,7 @@ bool exfat_fix_invalid_node_checksum(const struct exfat* ef,
 		struct exfat_node* node);
 bool exfat_fix_unknown_entry(struct exfat* ef, struct exfat_node* dir,
 		const struct exfat_entry* entry, off_t offset);
-
+bool exfat_fix_bad_timestamps(const struct exfat* ef,
+	struct exfat_node* node);
+	
 #endif /* ifndef EXFAT_H_INCLUDED */

--- a/libexfat/node.c
+++ b/libexfat/node.c
@@ -330,6 +330,14 @@ static int parse_file_entries(struct exfat* ef, struct exfat_node* node,
 	if (!check_node(ef, node, exfat_calc_checksum(entries, n), meta1))
 		return -EIO;
 
+	/* It's safe to assume a 0 unix timestamp means an error during
+	   exfat_exfat2unix conversion as time before exFAT epoch cannot be
+	   represented */
+	if(node->mtime == 0 || node->atime == 0) {
+		if(!EXFAT_REPAIR(bad_timestamps, ef, node))
+			return -EIO;
+	}
+
 	return 0;
 }
 

--- a/libexfat/repair.c
+++ b/libexfat/repair.c
@@ -100,3 +100,14 @@ bool exfat_fix_unknown_entry(struct exfat* ef, struct exfat_node* dir,
 	exfat_errors_fixed++;
 	return true;
 }
+
+bool exfat_fix_bad_timestamps(UNUSED const struct exfat* ef,
+	struct exfat_node* node)
+{
+	/* date & time will be rewritten by exfat_flush_node() */
+	node->is_dirty = true;
+
+	if(node->mtime == 0) exfat_errors_fixed++;
+	if(node->atime == 0) exfat_errors_fixed++;
+	return true;
+}


### PR DESCRIPTION
Flags bad modification and access dates and times (ERROR: bad date ...) as dirty so fsck can fix them.
